### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/compare/v0.1.0...v0.1.1) - 2026-03-10
+
+### Other
+
+- fix release-plz workflow to use PAT in checkout and action steps ([#4](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/pull/4))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "contentstack-api-client-rs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contentstack-api-client-rs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.93.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `contentstack-api-client-rs`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/compare/v0.1.0...v0.1.1) - 2026-03-10

### Other

- fix release-plz workflow to use PAT in checkout and action steps ([#4](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/pull/4))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).