### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/compare/v0.2.0...v0.3.0) - 2026-04-09
+
+### Added
+
+- *(params)* add derive traits and missing query fields ([#22](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/pull/22))
+- *(client)* make clients cloneable and improve configuration docs ([#20](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/pull/20))
+
 ## [0.2.0](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/compare/v0.1.1...v0.2.0) - 2026-04-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "contentstack-api-client-rs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "cargo-husky",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contentstack-api-client-rs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.93.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `contentstack-api-client-rs`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `contentstack-api-client-rs` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field GetOneParams.include_publish_details in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:91
  field GetOneParams.include_metadata in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:93
  field GetOneParams.environment in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:97
  field GetOneParams.include_publish_details in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:91
  field GetOneParams.include_metadata in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:93
  field GetOneParams.environment in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:97
  field GetOneParams.include_publish_details in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:91
  field GetOneParams.include_metadata in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:93
  field GetOneParams.environment in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:97
  field GetManyParams.asc in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:33
  field GetManyParams.desc in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:35
  field GetManyParams.include_publish_details in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:39
  field GetManyParams.include_metadata in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:41
  field GetManyParams.environment in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:45
  field GetManyParams.asc in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:33
  field GetManyParams.desc in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:35
  field GetManyParams.include_publish_details in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:39
  field GetManyParams.include_metadata in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:41
  field GetManyParams.environment in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:45
  field GetManyParams.asc in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:33
  field GetManyParams.desc in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:35
  field GetManyParams.include_publish_details in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:39
  field GetManyParams.include_metadata in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:41
  field GetManyParams.environment in /tmp/.tmpaB1oVv/contentstack-api-client-rs/src/client/params.rs:45
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/compare/v0.2.0...v0.3.0) - 2026-04-09

### Added

- *(params)* add derive traits and missing query fields ([#22](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/pull/22))
- *(client)* make clients cloneable and improve configuration docs ([#20](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/pull/20))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).