### PR TITLE
refactor!: unify entry fetching under EntriesGetter trait

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -6,6 +6,6 @@ pub mod params;
 
 pub use delivery::Delivery;
 pub use delivery::entries::Entries;
-pub use entries::{EntriesResponse, Entry, EntryResponse};
+pub use entries::{EntriesGetter, EntriesResponse, Entry, EntryResponse};
 pub use management::Management;
 pub use params::{GetManyParams, GetOneParams, Query};

--- a/src/client/delivery/entries.rs
+++ b/src/client/delivery/entries.rs
@@ -1,7 +1,7 @@
 use reqwest_middleware::ClientWithMiddleware;
-use serde::Deserialize;
+use serde::de::DeserializeOwned;
 
-use crate::client::entries::{EntriesResponse, EntryResponse};
+use crate::client::entries::{EntriesGetter, EntriesResponse, EntryResponse};
 use crate::client::params::{
     GetManyParams, GetOneParams, SerializedGetManyParams, SerializedGetOneParams,
 };
@@ -18,7 +18,6 @@ pub struct Entries<'a> {
 }
 
 impl<'a> Entries<'a> {
-    /// Builds the entries URL for a given content type, with an optional entry UID.
     fn build_url(&self, content_type: &str, uid: Option<&str>) -> String {
         let base_url = self.base_url.trim_end_matches('/');
         match uid {
@@ -26,7 +25,9 @@ impl<'a> Entries<'a> {
             None => format!("{}/content_types/{}/entries", base_url, content_type),
         }
     }
+}
 
+impl<'a> EntriesGetter for Entries<'a> {
     /// Fetches multiple entries for a given content type.
     ///
     /// # Arguments
@@ -38,7 +39,7 @@ impl<'a> Entries<'a> {
     ///
     /// ```no_run
     /// use serde::Deserialize;
-    /// use contentstack_api_client_rs::{Delivery, GetManyParams};
+    /// use contentstack_api_client_rs::{Delivery, EntriesGetter, GetManyParams};
     ///
     /// #[derive(Deserialize)]
     /// struct BlogPost { body: String }
@@ -53,14 +54,11 @@ impl<'a> Entries<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn get_many<T>(
+    async fn get_many<T: DeserializeOwned>(
         &self,
         content_type: &str,
         params: Option<GetManyParams>,
-    ) -> Result<EntriesResponse<T>>
-    where
-        T: for<'de> Deserialize<'de>,
-    {
+    ) -> Result<EntriesResponse<T>> {
         let request = self.client.get(self.build_url(content_type, None));
 
         let request = if let Some(p) = params {
@@ -85,7 +83,7 @@ impl<'a> Entries<'a> {
     ///
     /// ```no_run
     /// use serde::Deserialize;
-    /// use contentstack_api_client_rs::{Delivery, GetOneParams};
+    /// use contentstack_api_client_rs::{Delivery, EntriesGetter, GetOneParams};
     ///
     /// #[derive(Deserialize)]
     /// struct BlogPost { body: String }
@@ -100,15 +98,12 @@ impl<'a> Entries<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn get_one<T>(
+    async fn get_one<T: DeserializeOwned>(
         &self,
         content_type: &str,
         uid: &str,
         params: Option<GetOneParams>,
-    ) -> Result<EntryResponse<T>>
-    where
-        T: for<'de> Deserialize<'de>,
-    {
+    ) -> Result<EntryResponse<T>> {
         let request = self.client.get(self.build_url(content_type, Some(uid)));
 
         let request = if let Some(p) = params {

--- a/src/client/entries.rs
+++ b/src/client/entries.rs
@@ -1,4 +1,8 @@
 use serde::Deserialize;
+use serde::de::DeserializeOwned;
+
+use crate::client::params::{GetManyParams, GetOneParams};
+use crate::error::Result;
 
 /// A Contentstack entry with system fields plus caller-defined custom fields.
 ///
@@ -53,4 +57,68 @@ pub struct EntriesResponse<T> {
 #[derive(Debug, Deserialize)]
 pub struct EntryResponse<T> {
     pub entry: Entry<T>,
+}
+
+/// Shared contract for entry-fetching sub-clients.
+///
+/// Implemented by both [`crate::client::delivery::entries::Entries`] and
+/// [`crate::client::management::entries::Entries`]. Use this trait as a
+/// bound to write generic code that works with either client.
+///
+/// # Example
+///
+/// ```no_run
+/// use contentstack_api_client_rs::{Delivery, EntriesGetter};
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize)]
+/// struct BlogPost { body: String }
+///
+/// async fn fetch_all<E: EntriesGetter>(entries: E) {
+///     let response = entries.get_many::<BlogPost>("blog_post", None).await.unwrap();
+///     println!("{}", response.entries.len());
+/// }
+/// ```
+#[allow(async_fn_in_trait)]
+pub trait EntriesGetter {
+    /// Fetches multiple entries for a given content type.
+    async fn get_many<T: DeserializeOwned>(
+        &self,
+        content_type: &str,
+        params: Option<GetManyParams>,
+    ) -> Result<EntriesResponse<T>>;
+
+    /// Fetches a single entry by UID for a given content type.
+    ///
+    /// # Arguments
+    ///
+    /// * `content_type` - The content type UID (e.g. `"blog_post"`)
+    /// * `uid` - The entry UID to fetch
+    /// * `params` - Optional query parameters (locale, query filter)
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use contentstack_api_client_rs::{Delivery, EntriesGetter};
+    /// use serde::Deserialize;
+    ///
+    /// #[derive(Deserialize)]
+    /// struct BlogPost { body: String }
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Delivery::new("api_key", "token", "production", None);
+    /// let response = client.entries()
+    ///     .get_one::<BlogPost>("blog_post", "entry_uid_123", None)
+    ///     .await?;
+    ///
+    /// println!("Title: {}", response.entry.title);
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn get_one<T: DeserializeOwned>(
+        &self,
+        content_type: &str,
+        uid: &str,
+        params: Option<GetOneParams>,
+    ) -> Result<EntryResponse<T>>;
 }

--- a/src/client/management/entries.rs
+++ b/src/client/management/entries.rs
@@ -1,12 +1,15 @@
 use reqwest_middleware::ClientWithMiddleware;
-use serde::Deserialize;
+use serde::de::DeserializeOwned;
 
-use crate::client::entries::{EntriesResponse, EntryResponse};
+use crate::client::entries::{EntriesGetter, EntriesResponse, EntryResponse};
 use crate::client::params::{
     GetManyParams, GetOneParams, SerializedGetManyParams, SerializedGetOneParams,
 };
 use crate::error::Result;
 
+/// Sub-client for the Entries endpoint (Management API).
+///
+/// Obtained via [`crate::Management::entries`] — never constructed directly.
 pub struct Entries<'a> {
     pub(super) client: &'a ClientWithMiddleware,
     pub(super) base_url: &'a str,
@@ -20,15 +23,14 @@ impl<'a> Entries<'a> {
             None => format!("{}/content_types/{}/entries", base_url, content_type),
         }
     }
+}
 
-    pub async fn get_many<T>(
+impl<'a> EntriesGetter for Entries<'a> {
+    async fn get_many<T: DeserializeOwned>(
         &self,
         content_type: &str,
         params: Option<GetManyParams>,
-    ) -> Result<EntriesResponse<T>>
-    where
-        T: for<'de> Deserialize<'de>,
-    {
+    ) -> Result<EntriesResponse<T>> {
         let request = self.client.get(self.build_url(content_type, None));
 
         let request = if let Some(p) = params {
@@ -41,15 +43,12 @@ impl<'a> Entries<'a> {
         Ok(request.send().await?.json::<EntriesResponse<T>>().await?)
     }
 
-    pub async fn get_one<T>(
+    async fn get_one<T: DeserializeOwned>(
         &self,
         content_type: &str,
         uid: &str,
         params: Option<GetOneParams>,
-    ) -> Result<EntryResponse<T>>
-    where
-        T: for<'de> Deserialize<'de>,
-    {
+    ) -> Result<EntryResponse<T>> {
         let request = self.client.get(self.build_url(content_type, Some(uid)));
 
         let request = if let Some(p) = params {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod rate_limiter;
 pub use client::config::{ClientOptions, ClientType, Region};
 pub use client::{Delivery, Management};
 pub use client::{
-    Entries, EntriesResponse, Entry, EntryResponse, GetManyParams, GetOneParams, Query,
+    Entries, EntriesGetter, EntriesResponse, Entry, EntryResponse, GetManyParams, GetOneParams,
+    Query,
 };
 pub use error::ClientError;

--- a/tests/delivery_client.rs
+++ b/tests/delivery_client.rs
@@ -1,4 +1,4 @@
-use contentstack_api_client_rs::{ClientOptions, Delivery};
+use contentstack_api_client_rs::{ClientOptions, Delivery, EntriesGetter};
 use serde::Deserialize;
 use serde_json::json;
 use std::time::Duration;

--- a/tests/management_client.rs
+++ b/tests/management_client.rs
@@ -1,4 +1,4 @@
-use contentstack_api_client_rs::{ClientOptions, Management};
+use contentstack_api_client_rs::{ClientOptions, EntriesGetter, Management};
 use serde::Deserialize;
 use serde_json::json;
 use std::time::Duration;


### PR DESCRIPTION
BREAKING CHANGE: get_many and get_one are now part of the EntriesGetter trait. Users must import EntriesGetter to call these methods on the Entries sub-client.

* move get_many and get_one to EntriesGetter trait implementations
* use DeserializeOwned trait bound for generic deserialization
* fix stale doc references to EntriesFetcher in examples
* add missing documentation and examples for get_one
* export EntriesGetter for public use in both API clients