### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/compare/v0.3.0...v0.4.0) - 2026-04-13
+
+### Other
+
+- [**breaking**] unify entry fetching under EntriesGetter trait ([#23](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/pull/23))
+
 ## [0.3.0](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/compare/v0.2.0...v0.3.0) - 2026-04-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "contentstack-api-client-rs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "cargo-husky",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contentstack-api-client-rs"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.93.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `contentstack-api-client-rs`: 0.3.0 -> 0.4.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/compare/v0.3.0...v0.4.0) - 2026-04-13

### Other

- [**breaking**] unify entry fetching under EntriesGetter trait ([#23](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/pull/23))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).