### PR TITLE
feat(entries): support publish_details in Delivery and Management APIs

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+echo "Running pre-commit checks..."
+
+echo "  cargo fmt"
+cargo fmt --all

--- a/src/client/entries.rs
+++ b/src/client/entries.rs
@@ -36,9 +36,39 @@ pub struct Entry<T> {
     pub updated_by: String,
     #[serde(rename = "_version")]
     pub version: u32,
+    /// Details about when and where the entry was published.
+    /// Only present if `include_publish_details: true` was passed in params.
+    pub publish_details: Option<PublishDetails>,
     /// Caller's custom fields - flattened into the same JSON object.
     #[serde(flatten)]
     pub fields: T,
+}
+
+/// Information about the publication state of an entry.
+///
+/// The Contentstack Delivery API returns a single object, while the
+/// Management API returns a list of objects. This enum handles both cases
+/// transparently during deserialization.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum PublishDetails {
+    /// A single publication record (standard for Delivery API).
+    Single(PublishDetail),
+    /// Multiple publication records (standard for Management API).
+    Multiple(Vec<PublishDetail>),
+}
+
+/// A single publication record detailing the environment and locale.
+#[derive(Debug, Deserialize, Clone)]
+pub struct PublishDetail {
+    /// The environment UID where the entry is published.
+    pub environment: String,
+    /// The locale code (e.g., "en-us") of the published version.
+    pub locale: String,
+    /// ISO 8601 timestamp of the publication.
+    pub time: String,
+    /// The user UID who performed the publication.
+    pub user: String,
 }
 
 /// Response wrapper for a list of entries.

--- a/tests/delivery_client.rs
+++ b/tests/delivery_client.rs
@@ -65,6 +65,71 @@ async fn test_get_one_entry() {
 }
 
 #[tokio::test]
+async fn test_get_one_entry_with_publish_details() {
+    use contentstack_api_client_rs::{GetOneParams, client::entries::PublishDetails};
+
+    let mock_server = MockServer::start().await;
+
+    let response_body = json!({
+        "entry": {
+            "uid": "entry_123",
+            "title": "Hello Rust",
+            "locale": "en-us",
+            "created_at": "2024-01-01T00:00:00.000Z",
+            "updated_at": "2024-01-01T00:00:00.000Z",
+            "created_by": "user1",
+            "updated_by": "user1",
+            "_version": 1,
+            "publish_details": {
+                "environment": "production",
+                "locale": "en-us",
+                "time": "2024-01-01T12:00:00.000Z",
+                "user": "user1"
+            },
+            "body": "This is a test post"
+        }
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/content_types/blog_post/entries/entry_123"))
+        .and(wiremock::matchers::query_param(
+            "include_publish_details",
+            "true",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
+        .mount(&mock_server)
+        .await;
+
+    let client_opts = ClientOptions {
+        base_url: Some(mock_server.uri()),
+        timeout: Some(Duration::from_secs(1)),
+        max_connections: Some(10),
+        region: None,
+    };
+
+    let client = Delivery::new("test_api_key", "test_token", "test_env", Some(client_opts));
+
+    let params = GetOneParams {
+        include_publish_details: Some(true),
+        ..Default::default()
+    };
+
+    let response = client
+        .entries()
+        .get_one::<BlogPost>("blog_post", "entry_123", Some(params))
+        .await
+        .expect("Failed to fetch entry");
+
+    match response.entry.publish_details {
+        Some(PublishDetails::Single(details)) => {
+            assert_eq!(details.environment, "production");
+            assert_eq!(details.user, "user1");
+        }
+        _ => panic!("Expected Single publish_details"),
+    }
+}
+
+#[tokio::test]
 async fn test_client_cloning() {
     let client = Delivery::new("test_api_key", "test_token", "test_env", None);
     let cloned_client = client.clone();

--- a/tests/management_client.rs
+++ b/tests/management_client.rs
@@ -58,6 +58,80 @@ async fn test_get_one_entry() {
 }
 
 #[tokio::test]
+async fn test_get_one_entry_with_publish_details() {
+    use contentstack_api_client_rs::{GetOneParams, client::entries::PublishDetails};
+
+    let mock_server = MockServer::start().await;
+
+    let response_body = json!({
+        "entry": {
+            "uid": "entry_456",
+            "title": "Management Entry",
+            "locale": "en-us",
+            "created_at": "2024-01-01T00:00:00.000Z",
+            "updated_at": "2024-01-01T00:00:00.000Z",
+            "created_by": "user1",
+            "updated_by": "user1",
+            "_version": 2,
+            "publish_details": [
+                {
+                    "environment": "production",
+                    "locale": "en-us",
+                    "time": "2024-01-01T12:00:00.000Z",
+                    "user": "user1"
+                },
+                {
+                    "environment": "staging",
+                    "locale": "en-us",
+                    "time": "2024-01-02T12:00:00.000Z",
+                    "user": "user1"
+                }
+            ],
+            "body": "Written via management API"
+        }
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/content_types/blog_post/entries/entry_456"))
+        .and(wiremock::matchers::query_param(
+            "include_publish_details",
+            "true",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
+        .mount(&mock_server)
+        .await;
+
+    let client_opts = ClientOptions {
+        base_url: Some(mock_server.uri()),
+        timeout: Some(Duration::from_secs(1)),
+        max_connections: Some(10),
+        region: None,
+    };
+
+    let client = Management::new("test_api_key", "test_management_token", Some(client_opts));
+
+    let params = GetOneParams {
+        include_publish_details: Some(true),
+        ..Default::default()
+    };
+
+    let response = client
+        .entries()
+        .get_one::<BlogPost>("blog_post", "entry_456", Some(params))
+        .await
+        .expect("Failed to fetch entry");
+
+    match response.entry.publish_details {
+        Some(PublishDetails::Multiple(details)) => {
+            assert_eq!(details.len(), 2);
+            assert_eq!(details[0].environment, "production");
+            assert_eq!(details[1].environment, "staging");
+        }
+        _ => panic!("Expected Multiple publish_details"),
+    }
+}
+
+#[tokio::test]
 async fn test_get_many_entries() {
     let mock_server = MockServer::start().await;
 


### PR DESCRIPTION
- Add PublishDetails untagged enum to handle both object and vector formats
- Add PublishDetail struct to represent publication metadata
- Update Entry struct to include optional publish_details
- Add integration tests for both Delivery and Management API response formats