### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/compare/v0.4.0...v0.5.0) - 2026-04-13
+
+### Added
+
+- *(entries)* support publish_details in Delivery and Management APIs ([#25](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/pull/25))
+
 ## [0.4.0](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/compare/v0.3.0...v0.4.0) - 2026-04-13
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "contentstack-api-client-rs"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "cargo-husky",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contentstack-api-client-rs"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.93.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `contentstack-api-client-rs`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `contentstack-api-client-rs` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Entry.publish_details in /tmp/.tmpCEkozu/contentstack-api-client-rs/src/client/entries.rs:41
  field Entry.publish_details in /tmp/.tmpCEkozu/contentstack-api-client-rs/src/client/entries.rs:41
  field Entry.publish_details in /tmp/.tmpCEkozu/contentstack-api-client-rs/src/client/entries.rs:41
  field Entry.publish_details in /tmp/.tmpCEkozu/contentstack-api-client-rs/src/client/entries.rs:41
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/compare/v0.4.0...v0.5.0) - 2026-04-13

### Added

- *(entries)* support publish_details in Delivery and Management APIs ([#25](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/pull/25))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).