### PR TITLE
feat(environments): add support for fetching environment details

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,11 +1,13 @@
 pub mod config;
 pub mod delivery;
 pub mod entries;
+pub mod environments;
 pub mod management;
 pub mod params;
 
 pub use delivery::Delivery;
 pub use delivery::entries::Entries;
 pub use entries::{EntriesGetter, EntriesResponse, Entry, EntryResponse};
+pub use environments::{Environment, EnvironmentResponse};
 pub use management::Management;
 pub use params::{GetManyParams, GetOneParams, Query};

--- a/src/client/environments.rs
+++ b/src/client/environments.rs
@@ -1,0 +1,22 @@
+use serde::Deserialize;
+
+/// Represents an environment within a Contentstack stack.
+#[derive(Debug, Deserialize, Clone)]
+pub struct Environment {
+    /// The unique identifier (UID) of the environment.
+    pub uid: String,
+    /// The name of the environment (e.g., "production", "staging").
+    pub name: String,
+    /// A brief description of the environment.
+    pub description: Option<String>,
+    /// The deployment URL associated with this environment.
+    pub url: Option<String>,
+}
+
+/// Response wrapper for a single environment.
+///
+/// Contentstack returns `{ "environment": { ... } }`.
+#[derive(Debug, Deserialize)]
+pub struct EnvironmentResponse {
+    pub environment: Environment,
+}

--- a/src/client/environments.rs
+++ b/src/client/environments.rs
@@ -1,6 +1,22 @@
 use serde::Deserialize;
 
 /// Represents an environment within a Contentstack stack.
+///
+/// Environments are deployment destinations for content, such as "production",
+/// "staging", or "development".
+///
+/// # Example
+///
+/// ```
+/// use contentstack_api_client_rs::Environment;
+///
+/// let env = Environment {
+///     uid: "production_uid".to_string(),
+///     name: "production".to_string(),
+///     description: Some("Main production site".to_string()),
+///     url: Some("https://www.example.com".to_string()),
+/// };
+/// ```
 #[derive(Debug, Deserialize, Clone)]
 pub struct Environment {
     /// The unique identifier (UID) of the environment.
@@ -16,6 +32,21 @@ pub struct Environment {
 /// Response wrapper for a single environment.
 ///
 /// Contentstack returns `{ "environment": { ... } }`.
+///
+/// # Example
+///
+/// ```
+/// use contentstack_api_client_rs::{Environment, EnvironmentResponse};
+///
+/// let json = r#"{
+///     "environment": {
+///         "uid": "env_123",
+///         "name": "production"
+///     }
+/// }"#;
+/// let response: EnvironmentResponse = serde_json::from_str(json).unwrap();
+/// assert_eq!(response.environment.name, "production");
+/// ```
 #[derive(Debug, Deserialize)]
 pub struct EnvironmentResponse {
     pub environment: Environment,

--- a/src/client/management.rs
+++ b/src/client/management.rs
@@ -91,6 +91,18 @@ impl Management {
     }
 
     /// Returns an [`Environments`] sub-client for managing environments.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use contentstack_api_client_rs::Management;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Management::new("api_key", "token", None);
+    /// let response = client.environments().get("production_uid").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn environments(&self) -> Environments<'_> {
         Environments {
             client: &self.client,

--- a/src/client/management.rs
+++ b/src/client/management.rs
@@ -10,8 +10,10 @@ use crate::{
 };
 
 pub mod entries;
+pub mod environments;
 
 use entries::Entries;
+use environments::Environments;
 
 /// Async HTTP client for the Contentstack Content Management API.
 ///
@@ -83,6 +85,14 @@ impl Management {
     /// Returns an [`Entries`] sub-client for managing content entries.
     pub fn entries(&self) -> Entries<'_> {
         Entries {
+            client: &self.client,
+            base_url: &self.config.base_url,
+        }
+    }
+
+    /// Returns an [`Environments`] sub-client for managing environments.
+    pub fn environments(&self) -> Environments<'_> {
+        Environments {
             client: &self.client,
             base_url: &self.config.base_url,
         }

--- a/src/client/management.rs
+++ b/src/client/management.rs
@@ -99,7 +99,7 @@ impl Management {
     ///
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Management::new("api_key", "token", None);
-    /// let response = client.environments().get("production_uid").await?;
+    /// let response = client.environments().get_one("production_uid").await?;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/client/management/environments.rs
+++ b/src/client/management/environments.rs
@@ -1,6 +1,6 @@
-use reqwest_middleware::ClientWithMiddleware;
 use crate::client::environments::EnvironmentResponse;
 use crate::error::Result;
+use reqwest_middleware::ClientWithMiddleware;
 
 /// Sub-client for the Environments endpoint (Management API).
 ///

--- a/src/client/management/environments.rs
+++ b/src/client/management/environments.rs
@@ -29,12 +29,12 @@ impl<'a> Environments<'a> {
     ///
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Management::new("my_api_key", "my_token", None);
-    /// let response = client.environments().get("production_uid").await?;
+    /// let response = client.environments().get_one("production_uid").await?;
     /// println!("Name: {}", response.environment.name);
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn get(&self, uid: &str) -> Result<EnvironmentResponse> {
+    pub async fn get_one(&self, uid: &str) -> Result<EnvironmentResponse> {
         let request = self.client.get(self.build_url(uid));
         Ok(request.send().await?.json::<EnvironmentResponse>().await?)
     }

--- a/src/client/management/environments.rs
+++ b/src/client/management/environments.rs
@@ -1,0 +1,41 @@
+use reqwest_middleware::ClientWithMiddleware;
+use crate::client::environments::EnvironmentResponse;
+use crate::error::Result;
+
+/// Sub-client for the Environments endpoint (Management API).
+///
+/// Obtained via [`crate::Management::environments`] — never constructed directly.
+pub struct Environments<'a> {
+    pub(super) client: &'a ClientWithMiddleware,
+    pub(super) base_url: &'a str,
+}
+
+impl<'a> Environments<'a> {
+    fn build_url(&self, uid: &str) -> String {
+        let base_url = self.base_url.trim_end_matches('/');
+        format!("{}/environments/{}", base_url, uid)
+    }
+
+    /// Fetches detailed information about a specific environment.
+    ///
+    /// # Arguments
+    ///
+    /// * `uid` - The unique identifier (UID) of the environment to fetch.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use contentstack_api_client_rs::Management;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Management::new("my_api_key", "my_token", None);
+    /// let response = client.environments().get("production_uid").await?;
+    /// println!("Name: {}", response.environment.name);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get(&self, uid: &str) -> Result<EnvironmentResponse> {
+        let request = self.client.get(self.build_url(uid));
+        Ok(request.send().await?.json::<EnvironmentResponse>().await?)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@ pub mod rate_limiter;
 pub use client::config::{ClientOptions, ClientType, Region};
 pub use client::{Delivery, Management};
 pub use client::{
-    Entries, EntriesGetter, EntriesResponse, Entry, EntryResponse, Environment, EnvironmentResponse,
-    GetManyParams, GetOneParams, Query,
+    Entries, EntriesGetter, EntriesResponse, Entry, EntryResponse, Environment,
+    EnvironmentResponse, GetManyParams, GetOneParams, Query,
 };
 
 pub use error::ClientError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,8 @@ pub mod rate_limiter;
 pub use client::config::{ClientOptions, ClientType, Region};
 pub use client::{Delivery, Management};
 pub use client::{
-    Entries, EntriesGetter, EntriesResponse, Entry, EntryResponse, GetManyParams, GetOneParams,
-    Query,
+    Entries, EntriesGetter, EntriesResponse, Entry, EntryResponse, Environment, EnvironmentResponse,
+    GetManyParams, GetOneParams, Query,
 };
+
 pub use error::ClientError;

--- a/tests/management_client.rs
+++ b/tests/management_client.rs
@@ -232,7 +232,10 @@ async fn test_get_environment() {
 
     assert_eq!(response.environment.uid, "env_123");
     assert_eq!(response.environment.name, "production");
-    assert_eq!(response.environment.description.unwrap(), "Production environment");
+    assert_eq!(
+        response.environment.description.unwrap(),
+        "Production environment"
+    );
 }
 
 #[tokio::test]

--- a/tests/management_client.rs
+++ b/tests/management_client.rs
@@ -226,7 +226,7 @@ async fn test_get_environment() {
 
     let response = client
         .environments()
-        .get("env_123")
+        .get_one("env_123")
         .await
         .expect("Failed to fetch environment");
 

--- a/tests/management_client.rs
+++ b/tests/management_client.rs
@@ -194,6 +194,48 @@ async fn test_get_many_entries() {
 }
 
 #[tokio::test]
+async fn test_get_environment() {
+    let mock_server = MockServer::start().await;
+
+    let response_body = json!({
+        "environment": {
+            "uid": "env_123",
+            "name": "production",
+            "description": "Production environment",
+            "url": "https://example.com"
+        }
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/environments/env_123"))
+        .and(header("api_key", "test_api_key"))
+        .and(header("authorization", "test_management_token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client_opts = ClientOptions {
+        base_url: Some(mock_server.uri()),
+        timeout: Some(Duration::from_secs(1)),
+        max_connections: Some(10),
+        region: None,
+    };
+
+    let client = Management::new("test_api_key", "test_management_token", Some(client_opts));
+
+    let response = client
+        .environments()
+        .get("env_123")
+        .await
+        .expect("Failed to fetch environment");
+
+    assert_eq!(response.environment.uid, "env_123");
+    assert_eq!(response.environment.name, "production");
+    assert_eq!(response.environment.description.unwrap(), "Production environment");
+}
+
+#[tokio::test]
 async fn test_client_cloning() {
     let client = Management::new("test_api_key", "test_management_token", None);
     let cloned_client = client.clone();


### PR DESCRIPTION
- Implement Environments sub-client for Content Management API
- Add Environment and EnvironmentResponse data structures
- Expose environments() method on Management client
- Add integration tests for fetching environment details by UID
- Include rustdoc with usage examples for new public symbols