### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/compare/v0.5.0...v0.5.1) - 2026-04-13
+
+### Added
+
+- *(environments)* add support for fetching environment details ([#27](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/pull/27))
+
 ## [0.5.0](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/compare/v0.4.0...v0.5.0) - 2026-04-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "contentstack-api-client-rs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "cargo-husky",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contentstack-api-client-rs"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.93.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `contentstack-api-client-rs`: 0.5.0 -> 0.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.1](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/compare/v0.5.0...v0.5.1) - 2026-04-13

### Added

- *(environments)* add support for fetching environment details ([#27](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/pull/27))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).