### PR TITLE
feat(environments): add get_many method to Environments sub-client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -8,6 +8,6 @@ pub mod params;
 pub use delivery::Delivery;
 pub use delivery::entries::Entries;
 pub use entries::{EntriesGetter, EntriesResponse, Entry, EntryResponse};
-pub use environments::{Environment, EnvironmentResponse};
+pub use environments::{Environment, EnvironmentResponse, EnvironmentsResponse};
 pub use management::Management;
 pub use params::{GetManyParams, GetOneParams, Query};

--- a/src/client/environments.rs
+++ b/src/client/environments.rs
@@ -51,3 +51,27 @@ pub struct Environment {
 pub struct EnvironmentResponse {
     pub environment: Environment,
 }
+
+/// Response wrapper for a list of environments.
+///
+/// Contentstack returns `{ "environments": [...], "count": N }`.
+///
+/// # Example
+///
+/// ```
+/// use contentstack_api_client_rs::{Environment, EnvironmentsResponse};
+///
+/// let json = r#"{
+///     "environments": [
+///         { "uid": "env_1", "name": "production" }
+///     ],
+///     "count": 1
+/// }"#;
+/// let response: EnvironmentsResponse = serde_json::from_str(json).unwrap();
+/// assert_eq!(response.environments.len(), 1);
+/// ```
+#[derive(Debug, Deserialize)]
+pub struct EnvironmentsResponse {
+    pub environments: Vec<Environment>,
+    pub count: Option<u32>,
+}

--- a/src/client/management/environments.rs
+++ b/src/client/management/environments.rs
@@ -1,4 +1,5 @@
-use crate::client::environments::EnvironmentResponse;
+use crate::client::environments::{EnvironmentResponse, EnvironmentsResponse};
+use crate::client::params::{GetManyParams, SerializedGetManyParams};
 use crate::error::Result;
 use reqwest_middleware::ClientWithMiddleware;
 
@@ -11,9 +12,12 @@ pub struct Environments<'a> {
 }
 
 impl<'a> Environments<'a> {
-    fn build_url(&self, uid: &str) -> String {
+    fn build_url(&self, uid: Option<&str>) -> String {
         let base_url = self.base_url.trim_end_matches('/');
-        format!("{}/environments/{}", base_url, uid)
+        match uid {
+            Some(u) => format!("{}/environments/{}", base_url, u),
+            None => format!("{}/environments", base_url),
+        }
     }
 
     /// Fetches detailed information about a specific environment.
@@ -35,7 +39,42 @@ impl<'a> Environments<'a> {
     /// # }
     /// ```
     pub async fn get_one(&self, uid: &str) -> Result<EnvironmentResponse> {
-        let request = self.client.get(self.build_url(uid));
+        let request = self.client.get(self.build_url(Some(uid)));
         Ok(request.send().await?.json::<EnvironmentResponse>().await?)
+    }
+
+    /// Fetches a list of all environments available in a stack.
+    ///
+    /// # Arguments
+    ///
+    /// * `params` - Optional query parameters (pagination, include_count)
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use contentstack_api_client_rs::{Management, GetManyParams};
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Management::new("my_api_key", "my_token", None);
+    /// let params = GetManyParams {
+    ///     include_count: Some(true),
+    ///     ..Default::default()
+    /// };
+    /// let response = client.environments().get_many(Some(params)).await?;
+    /// println!("Total environments: {}", response.count.unwrap_or(0));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_many(&self, params: Option<GetManyParams>) -> Result<EnvironmentsResponse> {
+        let request = self.client.get(self.build_url(None));
+
+        let request = if let Some(p) = params {
+            let serialized: SerializedGetManyParams = p.into();
+            request.query(&serialized)
+        } else {
+            request
+        };
+
+        Ok(request.send().await?.json::<EnvironmentsResponse>().await?)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub use client::config::{ClientOptions, ClientType, Region};
 pub use client::{Delivery, Management};
 pub use client::{
     Entries, EntriesGetter, EntriesResponse, Entry, EntryResponse, Environment,
-    EnvironmentResponse, GetManyParams, GetOneParams, Query,
+    EnvironmentResponse, EnvironmentsResponse, GetManyParams, GetOneParams, Query,
 };
 
 pub use error::ClientError;

--- a/tests/management_client.rs
+++ b/tests/management_client.rs
@@ -239,6 +239,54 @@ async fn test_get_environment() {
 }
 
 #[tokio::test]
+async fn test_get_many_environments() {
+    let mock_server = MockServer::start().await;
+
+    let response_body = json!({
+        "environments": [
+            {
+                "uid": "env_1",
+                "name": "production"
+            },
+            {
+                "uid": "env_2",
+                "name": "staging"
+            }
+        ],
+        "count": 2
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/environments"))
+        .and(header("api_key", "test_api_key"))
+        .and(header("authorization", "test_management_token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client_opts = ClientOptions {
+        base_url: Some(mock_server.uri()),
+        timeout: Some(Duration::from_secs(1)),
+        max_connections: Some(10),
+        region: None,
+    };
+
+    let client = Management::new("test_api_key", "test_management_token", Some(client_opts));
+
+    let response = client
+        .environments()
+        .get_many(None)
+        .await
+        .expect("Failed to fetch environments");
+
+    assert_eq!(response.environments.len(), 2);
+    assert_eq!(response.environments[0].uid, "env_1");
+    assert_eq!(response.environments[1].name, "staging");
+    assert_eq!(response.count, Some(2));
+}
+
+#[tokio::test]
 async fn test_client_cloning() {
     let client = Management::new("test_api_key", "test_management_token", None);
     let cloned_client = client.clone();


### PR DESCRIPTION
- Implement get_many method for fetching a list of environments
- Add EnvironmentsResponse struct for list deserialization
- Update build_url to handle both list and single resource requests
- Add integration test for get_many functionality