### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/compare/v0.5.2...v0.6.0) - 2026-04-17
+
+### Added
+
+- add API error handling and bake /v3 into base URLs ([#31](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/pull/31))
+
 ## [0.5.2](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/compare/v0.5.1...v0.5.2) - 2026-04-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "contentstack-api-client-rs"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "cargo-husky",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contentstack-api-client-rs"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.93.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `contentstack-api-client-rs`: 0.5.2 -> 0.6.0 (⚠ API breaking changes)

### ⚠ `contentstack-api-client-rs` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant ClientError:Api in /tmp/.tmpQT7ery/contentstack-api-client-rs/src/error.rs:19
  variant ClientError:Api in /tmp/.tmpQT7ery/contentstack-api-client-rs/src/error.rs:19
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.0](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/compare/v0.5.2...v0.6.0) - 2026-04-17

### Added

- add API error handling and bake /v3 into base URLs ([#31](https://github.com/vitorbarbosagoncalves/contentstack-api-client-rs/pull/31))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).